### PR TITLE
Add line breaks and closing tags to template

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -190,7 +190,7 @@ export default class TextExpander extends Plugin {
 
         const changed = filesWithoutCurrent.map(file => repeatableContent.map(s => format(file, s)).join('\n'))
 
-        const result = heading.join('\n') + '\n' + changed.join('\n') + '\n' + footer.join('\n') + '\n\n' + this.lineEnding
+        const result =  '\n```\n\n' + heading.join('\n') + '\n' + changed.join('\n') + '\n' + footer.join('\n') + '\n\n' + this.lineEnding
 
         const fstLine = this.getFstLineNum(this.cm, n)
         const lstLine = this.getLastLineNum(this.cm, fstLine)

--- a/yarn.lock
+++ b/yarn.lock
@@ -204,8 +204,8 @@ minimatch@^3.0.4:
     brace-expansion "^1.1.7"
 
 "obsidian@https://github.com/obsidianmd/obsidian-api/tarball/master":
-  version "0.9.7"
-  resolved "https://github.com/obsidianmd/obsidian-api/tarball/master#8cbd761836526a23a1fcad9898f88bd337779bbe"
+  version "0.10.2"
+  resolved "https://github.com/obsidianmd/obsidian-api/tarball/master#58d88e75df55dd9f6902f51066536168535d95be"
   dependencies:
     "@types/codemirror" "0.0.98"
 


### PR DESCRIPTION
Previously, line breaks and closing tags were not being added properly to templates, causing tables to be added inline. Adds those in. 

Couldn't get it to yarn install on previous obsidian version.

Fixes https://github.com/mrjackphil/obsidian-text-expand/issues/18